### PR TITLE
Fix error from deprecated bindws

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,17 @@ Then just bind workspaces by prefixing numbers by the id of the monitor they're 
 Here, HDMI-A-1's id is 1, so I bind workspaces from 11 to 19 to it.
 
 ```
-  wsbind=1,DP-1
-  wsbind=2,DP-1
-  wsbind=3,DP-1
-  wsbind=4,DP-1
-  wsbind=5,DP-1
+  workspace=1,monitor:DP-1
+  workspace=2,monitor:DP-1
+  workspace=3,monitor:DP-1
+  workspace=4,monitor:DP-1
+  workspace=5,monitor:DP-1
 
-  wsbind=11,HDMI-A-1
-  wsbind=12,HDMI-A-1
-  wsbind=13,HDMI-A-1
-  wsbind=14,HDMI-A-1
-  wsbind=15,HDMI-A-1
+  workspace=11,monitor:HDMI-A-1
+  workspace=12,monitor:HDMI-A-1
+  workspace=13,monitor:HDMI-A-1
+  workspace=14,monitor:HDMI-A-1
+  workspace=15,monitor:HDMI-A-1
 ```
 
 Then it's just a matter of making sure your regular workspace keybinds call hyprsome.


### PR DESCRIPTION
I recently got a red error message saying:
"Config error at line 24 (~/.config/hypr/hyprland.conf): bindws has been deprecated in favor of workspace rules, see the wiki -> workspace rules
Hyprland may not work correctly".

This PR changes the relevant example in the README.md so that it uses workspace rules instead of wsbind.

Using this part of the example, I no longer get the same error and all seems to be working as should be.
Many thanks for this project btw :))