### PR TITLE
update nixpkg flake for latest build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685498995,
-        "narHash": "sha256-rdyjnkq87tJp+T2Bm1OD/9NXKSsh/vLlPeqCc/mm7qs=",
+        "lastModified": 1716128955,
+        "narHash": "sha256-3DNg/PV+X2V7yn8b/fUR2ppakw7D9N4sjVBGk6nDwII=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9cfaa8a1a00830d17487cb60a19bb86f96f09b27",
+        "rev": "f9256de8281f2ccd04985ac5c30d8f69aefadbe8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
When running nix build with the latest commit, the following error occurs.

```
❯ nix build
error: builder for '/nix/store/rmkngdl8k2sb9p8a5vf8j6lyylrdmn5s-hyprsome-deps-0.1.12.drv' failed with exit code 101;
       last 10 log lines:
       > will append /build/source/.cargo-home/config.toml with contents of /nix/store/d2h3p248qaxnjhgixjrxqhb844v4b3n5-vendor-cargo-deps/config.toml
       > default configurePhase, nothing to do
       > building
       > ++ command cargo --version
       > cargo 1.69.0
       > ++ command cargo check --release --all-targets
       > error: package `is_terminal_polyfill v1.70.0` cannot be built because it requires rustc 1.70.0 or newer, while the currently active rustc version is 1.69.0
       > Either upgrade to rustc 1.70.0 or newer, or use
       > cargo update -p is_terminal_polyfill@1.70.0 --precise ver
       > where `ver` is the latest version of `is_terminal_polyfill` supporting rustc 1.69.0
       For full logs, run 'nix log /nix/store/rmkngdl8k2sb9p8a5vf8j6lyylrdmn5s-hyprsome-deps-0.1.12.drv'.
error: 1 dependencies of derivation '/nix/store/2vwzns99jp7byfgl2xnzzqa02x8brai8-hyprsome-0.1.12.drv' failed to build
```

In hyprsome 0.1.12, some of the Rust toolchains required for building need to be updated to newer versions. The Rust toolchain installed by the existing nixpkg-unstable is outdated, so it will be updated.

```
 • Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/9cfaa8a1a00830d17487cb60a19bb86f96f09b27' (2023-05-31)
  → 'github:NixOS/nixpkgs/f9256de8281f2ccd04985ac5c30d8f69aefadbe8' (2024-05-19)
```